### PR TITLE
🐛 Arreglar error al quitar deptos

### DIFF
--- a/aplicaciones/www/src/pages/index.astro
+++ b/aplicaciones/www/src/pages/index.astro
@@ -62,7 +62,9 @@ import SelectorNivel from '@/componentes/SelectorNivel.astro';
 
           // Borrar si no está en la lista
           if (!lista.find((lugar) => lugar.codigo === mapita.id)) {
-            comparativo.removeChild(mapita);
+            if (comparativo.contains(mapita)) {
+              comparativo.removeChild(mapita);
+            }
           }
         });
 


### PR DESCRIPTION
🐛 Arreglar error al quitar deptos comprobando si el padre contiene al hijo.