### PR TITLE
🐛 cambio en assets bulid

### DIFF
--- a/aplicaciones/www/astro.config.mjs
+++ b/aplicaciones/www/astro.config.mjs
@@ -7,6 +7,6 @@ export default defineConfig({
   site: 'https://imagina.uniandes.edu.co',
   base: '/especiales/ninezya',
   build: {
-    assets: 'recursos',
+    assets: 'estaticos',
   },
 });


### PR DESCRIPTION
Pequeño cambio en la dirección donde el build manda los assets. En este repositorio no se llama `recursos`, se llama `estaticos`