### PR TITLE
🍭 colores para línea de tiempo y selección

### DIFF
--- a/aplicaciones/www/src/scss/estilos.scss
+++ b/aplicaciones/www/src/scss/estilos.scss
@@ -6,6 +6,40 @@
   // Fuentes
   --fuente: 'Recursive', 'Courier New', monospace;
 
+  // Colores línea de tiempo
+  --color1: #1818ff;
+  --color2: #ff771a;
+  --color3: #ff00ff;
+  --color4: #10b5ae;
+  --color5: #b4b800;
+  --color6: #570a8f;
+  --color7: #e40074;
+  --color8: #762e00;
+  --color9: #ffceff;
+  --color10: #03ffff;
+  --color11: #ff0400;
+  --color12: #557eff;
+  --color13: #ffc720;
+  --color14: #ad9987;
+  --color15: #ffa8b1;
+  --color16: #ea6eff;
+  --color17: #007876;
+  --color18: #dffd00;
+  --color19: #7dffa2;
+  --color20: #7d57a2;
+  --color21: #ffb46d;
+  --color22: #1b1a1a;
+  --color23: #af6c00;
+  --color24: #4dcc23;
+  --color25: #24467d;
+  --color26: #e0ff21;
+  --color27: #8ca2ff;
+  --color28: #d35446;
+  --color29: #cdeab6;
+  --color30: #bf3dc5;
+  --color31: #59708c;
+  --color32: #cfb428;
+
   // Colores NiñezYa Logo
   --aguaMarinaNinezYa: #a3ede3;
   --azulNinezYa: #32b6ff;


### PR DESCRIPTION
Lista de colores para las líneas de tiempo.

Como me lo imagino, van saliendo de una lista de colores, conforme se van seleccionando los departamentos o municipios, en ese orden que puse --color1; --color2; (...)

La línea de nacional sería :  
` --fucsiaEsmalte: #af067d;`

Se vería algo así:
![5_lineadetiempo_seleccion](https://github.com/enflujo/imagina-ninezya/assets/42554838/fd682ea7-a358-4e00-81b5-8b764a60d5d5)

