### PR TITLE
🐛 corregir umbral para cortar años

### DIFF
--- a/aplicaciones/www/src/componentes/LineaTiempo.astro
+++ b/aplicaciones/www/src/componentes/LineaTiempo.astro
@@ -261,7 +261,7 @@ const { alto, meta, umbral } = Astro.props;
 
     function crearEjeX() {
       const lista = listaAños.value;
-      const cortarAño = lista.length > 18;
+      const cortarAño = lista.length > 9;
       const lineaNacional = new Linea(
         contenedorLineas,
         'Colombia',


### PR DESCRIPTION
Cortar años a partir de 9 para que no se solapen en la línea de tiempo