### PR TITLE
➕ 🌵 Colores categóricos para los departamentos del mapa de Colombia 🌵➕

### DIFF
--- a/aplicaciones/www/src/scss/estilos.scss
+++ b/aplicaciones/www/src/scss/estilos.scss
@@ -6,39 +6,40 @@
   // Fuentes
   --fuente: 'Recursive', 'Courier New', monospace;
 
-  // Colores línea de tiempo
-  --color0: #1818ff;
-  --color1: #ff771a;
-  --color2: #ff00ff;
-  --color3: #10b5ae;
-  --color4: #93b800;
-  --color5: #8f0a82;
-  --color6: #e40074;
-  --color7: #762e00;
-  --color8: #0088ff;
-  --color9: #03ffff;
-  --color10: #ff0400;
-  --color11: #557eff;
-  --color12: #4639cb;
-  --color13: #815eff;
-  --color14: #49117e;
-  --color15: #ea6eff;
-  --color16: #007876;
-  --color17: #ad6800;
-  --color18: #7dffa2;
-  --color19: #513f64;
-  --color20: #581f9e;
-  --color21: #1b1a1a;
-  --color22: #cc238b;
-  --color23: #af6c00;
-  --color24: #24467d;
-  --color25: #6a742c;
-  --color26: #8ca2ff;
-  --color27: #d35446;
-  --color28: #ffae00;
-  --color29: #bf3dc5;
-  --color30: #59708c;
-  --color31: #6f3462;
+  // Colores línea de tiempo - Paleta de Colores Categóricos
+
+  --color0: #4b0082;  // ANTIOQUIA - índigo 
+  --color1: #0000ff;  // ATLÁNTICO - azul puro 
+  --color2: #8a2be2;  // BOGOTA D.C. - azul violeta 
+  --color3: #ff4500;  // BOLIVAR - naranja rojizo 
+  --color4: #2e8b57;  // BOYACA - verde esmeralda 
+  --color5: #ffd700;  // CALDAS - dorado 
+  --color6: #7b68ee;  // CAQUETA - azul mediano 
+  --color7: #ff6347;  // CAUCA - rojo tomate 
+  --color8: #4682b4;  // CESAR - azul acero 
+  --color9: #daa520;  // CORDOBA - oro viejo
+  --color10: #5f9ea0; // CUNDINAMARCA - azul cadete 
+  --color11: #8b4513; // CHOCO - marrón madera 
+  --color12: #7fff00; // HUILA - verde chillón 
+  --color13: #d2691e; // LA GUAJIRA - marron chocolate 
+  --color14: #40e0d0; // MAGDALENA - turquesa 
+  --color15: #ff1493; // META rosa intenso 
+  --color16: #b22222; // NARIÑO - rojo fuego 
+  --color17: #8fbc8f; // NORTE DE SANTANDER - verde oscuro pálido 
+  --color18: #ff69b4; // QUINDIO - rosa fuerte 
+  --color19: #008080; // RISARALDA - teal 
+  --color20: #b8860b; // SANTANDER - dorado oscuro 
+  --color21: #b0e0e6; // SUCRE - azul pálido 
+  --color22: #ffa07a; // TOLIMA - salmón claro 
+  --color23: #6a5acd; // VALLE DEL CAUCA - azul pizarra 
+  --color24: #ff00ff; // ARAUCA magenta 
+  --color25: #2f4f4f; // CASANARE - gris pizarra oscuro 
+  --color26: #556b2f; // PUTUMAYO - verde oliva oscuro 
+  --color27: #d3d3d3; // AMAZONAS - gris claro 
+  --color28: #00008b; // GUANÍA - azul oscuro 
+  --color29: #00ced1; // GUAVIARE - turquesa oscuro 
+  --color30: #ff8c00; // VAUPES - naranja oscuro 
+  --color31: #deb887; // VICHADA - marrón beige
 
   // Colores NiñezYa Logo
   --aguaMarinaNinezYa: #a3ede3;


### PR DESCRIPTION
Cambié la paleta de colores para diferenciar cada departamento de Colombia en el mapa de Niñez YA.
Los bordes de cada departamento se pintan de un color diferente, intentando evitar que se confundan con los departamentos cercanos/adyacentes.